### PR TITLE
add video.txt to fastlane

### DIFF
--- a/fastlane/metadata/android/en-US/video.txt
+++ b/fastlane/metadata/android/en-US/video.txt
@@ -1,0 +1,1 @@
+https://www.youtube.com/watch?v=0jtzA3alpuw


### PR DESCRIPTION
As [requested here](https://github.com/aicodix/rattlegram/pull/41#issuecomment-3146244396), the missing `video.txt` for the fastlane tree.